### PR TITLE
feat(validationAction): Criando um pacote para automatizar a validação de links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build
+.swiftpm
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:5.4.0
+import PackageDescription
+
+let package = Package(
+    name: "LinkValidator",
+    targets: [
+        .target(name: "LinkValidator"),
+        .testTarget(name: "LinkValidatorTests",
+                    dependencies: ["LinkValidator"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Esta seção contém links sobre conteúdos específicos relacionados à linguag
 - [AppCoda](https://www.appcoda.com/ios-programming-course/)
 - [Hacking With Swift](https://www.hackingwithswift.com/learn)
 - [Raywenderlich](https://www.raywenderlich.com/ios/paths)
-- [LearnAppMaking](https://learnappmaking.com/blog/)
+- [LearnAppMaking](https://learnappmaking.com/)
 - [Daily Dose of Swift](https://dailydoseofswift.com)
 - [Flawless App Stories](https://medium.com/flawless-app-stories) 
 - [iOS Dev Weekly](https://iosdevweekly.com)
@@ -76,7 +76,7 @@ Esta seção contém links sobre conteúdos específicos relacionados à linguag
 - [Attekita Dev](https://www.youtube.com/channel/UCetRsdZxDQDcgVDJd6erz6g)
 - [Cícero Camargo CODEMUS](https://www.youtube.com/c/C%C3%ADceroCamargoCODEMUS/)
 - [Raphael Oliveira](https://www.youtube.com/rapholivera)
-- [Thais Sadami](https://www.youtube.com/thaissad.ami)
+- [Thais Sadami](https://www.youtube.com/ThaisSadami)
 - [iOS Academy](https://www.youtube.com/channel/UCnksRRifsSCGUZpQukUKAyg)
 - [Rebeloper](https://www.youtube.com/channel/UCK88iDIf2V6w68WvC-k7jcg)
 - [Vincent Pradeilles](https://www.youtube.com/c/VincentPradeilles)
@@ -96,15 +96,15 @@ Esta seção contém links sobre conteúdos específicos relacionados à linguag
 - [Swift by Sundell](https://www.swiftbysundell.com/podcast)
 - [Fireside Swift](https://www.firesideswift.com/)
 - [Swift Unwrapped](https://spec.fm/podcasts/swift-unwrapped)
-- [Compile Swift](compileswift.com/episodes)
+- [Compile Swift](https:/compileswift.com/episodes)
 - [iOS dev Discussions](https://open.spotify.com/show/6X6CHU9oxkwG9JlQYFZpbk?si=zFrV6Mk4QPGPHp-xginj4w&dl_branch=1)
 
 ## Cursos Gratuitos
 
 - [Aprendendo Swift do Iniciante ao Avançado - Udemy](https://www.udemy.com/course/aprendendoswift3/)
 - [iOS 13 & Swift 5 - Recriando o Tinder 2020](https://www.udemy.com/course/ios-13-swift-5-recriando-o-tinder-2020/)
-- [Conhecendo a base do Swift - Digital Innovation One](https://web.digitalinnovation.one/course/conhecendo-a-base-do-swift/learning/ccfecff3-da40-4b1a-bd13-3bbdc29950a6/)
-- [Criando um aplicativo com SwiftUI e Combine - Digital Innovation One](https://web.digitalinnovation.one/course/criando-um-aplicativo-com-swiftui-e-combine/learning/9f50bf10-c6b1-4c8a-8396-7c5be027b91e/?back=/browse)
+- [Conhecendo a base do Swift - Digital Innovation One](https://digitalinnovation.one/cursos/conhecendo-a-base-do-swift)
+- [Criando um aplicativo com SwiftUI e Combine - Digital Innovation One](https://digitalinnovation.one/cursos/criando-um-aplicativo-com-swiftui-e-combine)
 
 ## Roadmaps
 

--- a/Sources/LinkValidator/LinkValidator.swift
+++ b/Sources/LinkValidator/LinkValidator.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+class LinkValidator {
+    
+    public static var shared: LinkValidator = {
+        return LinkValidator()
+    }()
+    
+    @available(macOS 10.11, *)
+    func readFileText(_ filename: String) throws -> String {
+        if let fileURL = Bundle.main.path(forResource: filename, ofType: "txt") {
+            let text = try String(contentsOfFile: fileURL, encoding: .utf8)
+            return text
+        } else {
+            let projectDirectory = URL(fileURLWithPath: ProcessInfo.processInfo.environment["SRCROOT"] ?? "")
+            let fileURL = URL(fileURLWithPath: filename, relativeTo: projectDirectory)
+            let text = try String(contentsOf: fileURL, encoding: .utf8)
+            return text
+        }
+    }
+}

--- a/Tests/LinkValidatorTests/main.swift
+++ b/Tests/LinkValidatorTests/main.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+@testable import LinkValidator
+
+class LinksTest : XCTestCase {
+    
+    var regex: NSRegularExpression?
+    
+    override func setUp() {
+        do {
+            regex = try NSRegularExpression(pattern: #"(?:\[.*\])\((?<link>.*)\)"#)
+        } catch(let error) {
+            XCTFail(error.localizedDescription)
+        }
+    }
+    
+    func testLinks() throws {
+        
+        let text = try LinkValidator.shared.readFileText("README.md")
+        
+        XCTAssertNotNil(text, "Foi impossível ler o arquivo README.md")
+        XCTAssertGreaterThan(text.count, 0, "O arquivo está vazio")
+        
+        let textRange = NSRange(text.startIndex..., in: text)
+        let links: [String]? = regex?.matches(in: text, options: [], range: textRange)
+            .map {
+                let matchRange = Range($0.range(withName: "link"), in: text)!
+                return String(text[matchRange])
+                }
+        
+        XCTAssertGreaterThan(links?.count ?? 0, 0, "URLS não encontrados no arquivo")
+        XCTAssertNotNil(links, "A lista de links não foi obtida")
+        
+        for link in links! {
+            let expectation = XCTestExpectation(description: "Carregar a página \(link)")
+
+            let url = URL(string: link)!
+            let task = URLSession.shared.dataTask(with: url, completionHandler: { (data,response,error) in
+                XCTAssertNil(error, "A página \(link) não foi encontrada")
+                if let httpResponse = response as? HTTPURLResponse {
+                    XCTAssertEqual(httpResponse.statusCode, 200,
+                                   String(format: "A página %@ não está disponível", httpResponse.url?.absoluteString ?? ""))
+                } else {
+                    XCTFail(String(format: "A página %@ falhou", link))
+                }
+                expectation.fulfill()
+            })
+            task.resume()
+            wait(for: [expectation], timeout: 5.0)
+        }
+        
+    }
+}
+
+

--- a/main.swift
+++ b/main.swift
@@ -1,1 +1,0 @@
-print("Hello World!")


### PR DESCRIPTION
## O quê?
Criei um pacote usando o [SPM](https://swift.org/package-manager/) para validar os links. O pacote basicamente lê o arquivo `README.md`, usa uma RegEx para buscar os links e faz uma requisição em cada um deles para verificar se o link foi encontrado e a requisição retornou um status 200. O script já foi testado no arquivo e inclusive alguns links foram corrigidos, pois haviam sido alterados ou estavam incorretos.

## Como?
O script criado encontra-se na pasta `Source/LinkValidator`, e criei uma suíte de teste que faz o uso do script. O teste foi criado para poder ser utilizado em uma GitHub Action. Toda vez que alguém submeter um PR ou os links forem alterados na branch principal, a action será executada e irá verificar se todos os links estão corretos. Caso algum apresente problemas, o teste irá falhar, seremos informados e poderemos corrigir.