### PR TITLE
[#14] Adicionando fila de links ao workflow de validação

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "LinkValidator",
     targets: [
-        .target(name: "LinkValidator"),
+        .target(name: "LinkValidator", resources: [.copy("README.md")]),
         .testTarget(name: "LinkValidatorTests",
                     dependencies: ["LinkValidator"])
     ]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Esta seção contém links sobre conteúdos específicos relacionados à linguag
 
 ### Linguagem
 
-- [O que são Classes e Struct, as diferenças e quando usar - Giovanna Moeller [🇧🇷] ](https://www.alura.com.br/artigos/ios-swift-classes-struct-diferencas-usar)
+- [Variáveis e Constantes em Swift - ReisDev [🇧🇷]](https://dev.to/reisdev/variaveis-e-constantes-em-swift-1ddm)
+- [O que são Classes e Struct, as diferenças e quando usar - Giovanna Moeller [🇧🇷]](https://www.alura.com.br/artigos/ios-swift-classes-struct-diferencas-usar)
 - [Opcionais em Swift: como utilizar? - Giovanna Moeller [🇧🇷] ](https://www.alura.com.br/artigos/ios-opcionais-swift)
 - [Entendendo o uso de Generics: Por quê e como utilizar? - Giovanna Moeller [🇧🇷]](https://www.alura.com.br/artigos/ios-swift-entendendo-uso-generics-por-que-como-utilizar)
 - [Como funcionam os modificadores de acesso? - Giovanna Moeller [🇧🇷]](https://www.alura.com.br/artigos/ios-swift-como-funcionam-modificadores-de-acesso)

--- a/Sources/LinkValidator/LinkValidator.swift
+++ b/Sources/LinkValidator/LinkValidator.swift
@@ -8,12 +8,11 @@ class LinkValidator {
     
     @available(macOS 10.11, *)
     func readFileText(_ filename: String) throws -> String {
-        if let fileURL = Bundle.main.path(forResource: filename, ofType: "txt") {
+        if let fileURL = Bundle.main.path(forResource: filename, ofType: "md") {
             let text = try String(contentsOfFile: fileURL, encoding: .utf8)
             return text
         } else {
-            let projectDirectory = URL(fileURLWithPath: ProcessInfo.processInfo.environment["SRCROOT"] ?? "")
-            let fileURL = URL(fileURLWithPath: filename, relativeTo: projectDirectory)
+            let fileURL = URL(fileURLWithPath: "README.md")
             let text = try String(contentsOf: fileURL, encoding: .utf8)
             return text
         }

--- a/Tests/LinkValidatorTests/main.swift
+++ b/Tests/LinkValidatorTests/main.swift
@@ -4,6 +4,8 @@ import XCTest
 
 class LinksTest : XCTestCase {
     
+    var queue: [String] = []
+    var triesCount: [String:Int] = [:]
     var regex: NSRegularExpression?
     
     override func setUp() {
@@ -16,39 +18,61 @@ class LinksTest : XCTestCase {
     
     func testLinks() throws {
         
-        let text = try LinkValidator.shared.readFileText("README.md")
+        do {
+            let text = try LinkValidator.shared.readFileText("README")
+            
+            XCTAssertNotNil(text, "Foi impossível ler o arquivo README.md")
+            XCTAssertGreaterThan(text.count, 0, "O arquivo está vazio")
+            
+            self.queue = extractLinksFromText(text)
+            
+            XCTAssertGreaterThan(queue.count, 0, "URLS não encontrados no arquivo")
+            
+            while !queue.isEmpty {
+                guard let link = queue.last, let url = URL(string: link) else { continue }
+                
+                let expectation = XCTestExpectation(description: "Carregar a página \(link)")
+                
+                let task = URLSession.shared.dataTask(with: url, completionHandler: { (data,response,error) in
+                    XCTAssertNil(error, "A página \(link) não foi encontrada")
+                    
+                    if let httpResponse = response as? HTTPURLResponse {
+                        XCTAssertTrue((200...299).contains(httpResponse.statusCode),"A página \(link) não está disponível")
+                        let _ = self.queue.popLast()
+                    } else {
+                        if let count = self.triesCount[link] {
+                            if count == 3 {
+                                let _ = self.queue.popLast()
+                                XCTFail("A página \(link) está fora do ar")
+                            } else {
+                                self.triesCount[link] = count + 1
+                            }
+                        } else {
+                            self.triesCount[link] = 1
+                        }
+                    }
+                    expectation.fulfill()
+                })
+                task.resume()
+                wait(for: [expectation], timeout: 10.0)
+            }
+        } catch (let error) {
+            XCTFail(error.localizedDescription)
+        }
         
-        XCTAssertNotNil(text, "Foi impossível ler o arquivo README.md")
-        XCTAssertGreaterThan(text.count, 0, "O arquivo está vazio")
-        
+    }
+}
+
+extension LinksTest {
+    private func extractLinksFromText(_ text: String) -> [String] {
+        guard let regex = regex else { return [] }
         let textRange = NSRange(text.startIndex..., in: text)
-        let links: [String]? = regex?.matches(in: text, options: [], range: textRange)
+        
+        return regex.matches(in: text, options: [], range: textRange)
             .map {
                 let matchRange = Range($0.range(withName: "link"), in: text)!
                 return String(text[matchRange])
             }.filter { $0.starts(with: "http") }
-        
-        XCTAssertGreaterThan(links?.count ?? 0, 0, "URLS não encontrados no arquivo")
-        XCTAssertNotNil(links, "A lista de links não foi obtida")
-        
-        for link in links! {
-            let expectation = XCTestExpectation(description: "Carregar a página \(link)")
-
-            let url = URL(string: link)!
-            let task = URLSession.shared.dataTask(with: url, completionHandler: { (data,response,error) in
-                XCTAssertNil(error, "A página \(link) não foi encontrada")
-                if let httpResponse = response as? HTTPURLResponse {
-                    XCTAssertEqual(httpResponse.statusCode, 200,
-                                   String(format: "A página %@ não está disponível", httpResponse.url?.absoluteString ?? ""))
-                } else {
-                    XCTFail(String(format: "A página %@ falhou", link))
-                }
-                expectation.fulfill()
-            })
-            task.resume()
-            wait(for: [expectation], timeout: 10.0)
-        }
-        
     }
 }
 

--- a/Tests/LinkValidatorTests/main.swift
+++ b/Tests/LinkValidatorTests/main.swift
@@ -34,12 +34,12 @@ class LinksTest : XCTestCase {
 
                 guard let link = queue.first , let url = URL(string: link) else {
                     if let first = queue.first {
-                        XCTFail("Não foi possível gerar a URL para o link \(first)")
+                        debugPrint("O link \(first) apresentou algum problema e não pode ser validado")
                         removeFailedURL(link: first)
                     }
                     continue
                 }
-                            
+
                 let expectation = XCTestExpectation(description: "Carregar a página \(link)")
                 
                 let task = urlSession.dataTask(with: url) { (data,response,error) in

--- a/Tests/LinkValidatorTests/main.swift
+++ b/Tests/LinkValidatorTests/main.swift
@@ -55,7 +55,7 @@ class LinksTest : XCTestCase {
                             self.triesCount[link] = count + 1
                         } else {
                             self.removeFailedURL(link: link)
-                            XCTFail("A página \(link) está fora do ar")
+                            XCTFail("Não foi possível validar a página \(link)")
                             return
                         }
                     } else {

--- a/Tests/LinkValidatorTests/main.swift
+++ b/Tests/LinkValidatorTests/main.swift
@@ -39,13 +39,10 @@ class LinksTest : XCTestCase {
                     }
                     continue
                 }
-                
-                var request = URLRequest(url: url)
-                request.httpMethod = "HEAD"
                             
                 let expectation = XCTestExpectation(description: "Carregar a página \(link)")
                 
-                let task = urlSession.dataTask(with: request) { (data,response,error) in
+                let task = urlSession.dataTask(with: url) { (data,response,error) in
                     
                     if let errorDescription = error?.localizedDescription {
                         XCTFail("Ocorreu um erro ao acessar o link \(link): \(errorDescription)")


### PR DESCRIPTION
Este PR resolve a issue #14. Adicionei uma fila de links a serem validados e um contador de quantidade de tentativas, atualmente limitado a 3. Sempre que um link é validado, ele é removido da fila. Se ele falhar 3 vezes, também será removido.